### PR TITLE
Set Volume Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can adjust the volume of the sounds by executing these commands in the Comma
 
 - `Hacker Sounds: Volume Up`
 - `Hacker Sounds: Volume Down`
+- `Hacker Sounds: Set Volume`
 
 **NOTE:** The volume adjustments only apply to this extension's sounds. It does not affect the system volume.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,9 +69,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.12.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-			"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+			"version": "12.20.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.45.tgz",
+			"integrity": "sha512-1Jg2Qv5tuxBqgQV04+wO5u+wmSHbHgpORCJdeCLM+E+YdPElpdHhgywU+M1V1InL8rfOtpqtOjswk+uXTKwx7w==",
 			"dev": true
 		},
 		"@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@types/glob": "^7.1.1",
         "@types/lodash.debounce": "^4.0.6",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^12.20.45",
+        "@types/node": "^12.11.7",
         "@types/vscode": "^1.40.0",
         "glob": "^7.1.5",
         "mocha": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
             {
                 "command": "hacker_sounds.volumeDown",
                 "title": "Hacker Sounds: Volume Down"
+            },
+            {
+                "command": "hacker_sounds.setVolume",
+                "title": "Hacker Sounds: Set Volume",
+                "args" : "newVol"
             }
         ]
     },
@@ -59,7 +64,7 @@
         "@types/glob": "^7.1.1",
         "@types/lodash.debounce": "^4.0.6",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^12.11.7",
+        "@types/node": "^12.20.45",
         "@types/vscode": "^1.40.0",
         "glob": "^7.1.5",
         "mocha": "^6.2.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,11 +167,11 @@ export function activate(context: vscode.ExtensionContext) {
 
             case 'win32':
                 if(newVol > 100) {
-                    vscode.window.showInformationMessage("Volume has been changed to 100 which is the maximum volume")
+                    vscode.window.showInformationMessage("Volume has been increased to 100 which is the maximum volume")
                     config.winVol = 100;
                 } 
                 else if(newVol < 10) {
-                    vscode.window.showInformationMessage("Volume has been changed to 10 which is the minimum volume")
+                    vscode.window.showInformationMessage("Volume has been decreased to 10 which is the minimum volume")
                     config.winVol = 10
                 } else {
                     if(config.winVol < newVol)
@@ -188,11 +188,11 @@ export function activate(context: vscode.ExtensionContext) {
 
             case 'linux':
                 if(newVol > 10) {
-                    vscode.window.showInformationMessage("Volume has been changed to 10 which is the maximum volume")
+                    vscode.window.showInformationMessage("Volume has been increased to 10 which is the maximum volume")
                     config.linuxVol = 10;
                 }
                 else if(newVol < 1) {
-                    vscode.window.showInformationMessage("Volume has been changed to 1 which is the minimum volume")
+                    vscode.window.showInformationMessage("Volume has been decreased to 1 which is the minimum volume")
                     config.linuxVol = 1
                 } else {
                     if(config.linuxVol < newVol)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import player, { PlayerConfig } from './player';
 import debounce = require('lodash.debounce');
+import { toInteger } from 'lodash';
 
 let listener: EditorListener;
 let isActive: boolean;
@@ -47,7 +48,6 @@ export function activate(context: vscode.ExtensionContext) {
     });
     vscode.commands.registerCommand('hacker_sounds.volumeUp', () => {
         let newVol = null;
-
         switch (process.platform) {
             case 'darwin':
                 config.macVol += 1;
@@ -140,6 +140,65 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage('Hacker Sounds volume lowered: ' + newVol);
     });
 
+    vscode.commands.registerCommand('hacker_sounds.setVolume', async () => {
+        let input = await vscode.window.showInputBox()
+        let newVol = toInteger(input);
+        switch (process.platform) {
+            case 'darwin':
+                    if(newVol > 10) {
+                        vscode.window.showInformationMessage("Volume has been changed to 10 which is the maximum volume")
+                        config.macVol = 10;
+                    } 
+                    else if(newVol < 10) {
+                        vscode.window.showInformationMessage("Volume has been changed to 1 which is the minimum volume")
+                        config.macVol = 1
+                    } else {
+                        vscode.window.showInformationMessage("Volume has been changed to " + newVol)
+                        config.macVol = newVol;
+                    }
+
+                context.globalState.update('mac_volume', newVol);
+                break;
+
+            case 'win32':
+                if(newVol > 100) {
+                    vscode.window.showInformationMessage("Volume has been changed to 100 which is the maximum volume")
+                    config.winVol = 100;
+                } 
+                else if(newVol < 10) {
+                    vscode.window.showInformationMessage("Volume has been changed to 10 which is the minimum volume")
+                    config.winVol = 10
+                } else {
+                    vscode.window.showInformationMessage("Volume has been changed to " + newVol)
+                    config.winVol = newVol;
+                }
+
+            context.globalState.update('win_volume', newVol);
+            break;
+
+            case 'linux':
+                if(newVol > 10) {
+                    vscode.window.showInformationMessage("Volume has been changed to 10 which is the maximum volume")
+                    config.winVol = 10;
+                }
+                else if(newVol < 1) {
+                    vscode.window.showInformationMessage("Volume has been changed to 1 which is the minimum volume")
+                    config.winVol = 1
+                } else {
+                    vscode.window.showInformationMessage("Volume has been changed to " + newVol)
+                    config.winVol = newVol;
+                }
+
+            context.globalState.update('linux_volume', newVol);
+            break;
+
+            default:
+                newVol = 0;
+                break;
+        }
+    });
+
+    
     // Add to a list of disposables which are disposed when this extension is deactivated.
     context.subscriptions.push(listener);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,14 +146,19 @@ export function activate(context: vscode.ExtensionContext) {
         switch (process.platform) {
             case 'darwin':
                     if(newVol > 10) {
-                        vscode.window.showInformationMessage("Volume has been changed to 10 which is the maximum volume")
+                        vscode.window.showInformationMessage("Volume has been increased to 10 which is the maximum volume")
                         config.macVol = 10;
                     } 
                     else if(newVol < 10) {
-                        vscode.window.showInformationMessage("Volume has been changed to 1 which is the minimum volume")
+                        vscode.window.showInformationMessage("Volume has been decreased to 1 which is the minimum volume")
                         config.macVol = 1
                     } else {
-                        vscode.window.showInformationMessage("Volume has been changed to " + newVol)
+                        if(config.macVol < newVol)
+                        vscode.window.showInformationMessage("Volume has been increased to " + newVol)
+                        else if(config.macVol > newVol)
+                        vscode.window.showInformationMessage("Volume has been decreased to " + newVol)
+                        else
+                        vscode.window.showWarningMessage("Volume is always at " + newVol);
                         config.macVol = newVol;
                     }
 
@@ -169,7 +174,12 @@ export function activate(context: vscode.ExtensionContext) {
                     vscode.window.showInformationMessage("Volume has been changed to 10 which is the minimum volume")
                     config.winVol = 10
                 } else {
-                    vscode.window.showInformationMessage("Volume has been changed to " + newVol)
+                    if(config.winVol < newVol)
+                    vscode.window.showInformationMessage("Volume has been increased to " + newVol)
+                    else if(config.winVol > newVol)
+                    vscode.window.showInformationMessage("Volume has been decreased to " + newVol)
+                    else
+                    vscode.window.showWarningMessage("Volume is always at " + newVol);
                     config.winVol = newVol;
                 }
 
@@ -179,14 +189,19 @@ export function activate(context: vscode.ExtensionContext) {
             case 'linux':
                 if(newVol > 10) {
                     vscode.window.showInformationMessage("Volume has been changed to 10 which is the maximum volume")
-                    config.winVol = 10;
+                    config.linuxVol = 10;
                 }
                 else if(newVol < 1) {
                     vscode.window.showInformationMessage("Volume has been changed to 1 which is the minimum volume")
-                    config.winVol = 1
+                    config.linuxVol = 1
                 } else {
-                    vscode.window.showInformationMessage("Volume has been changed to " + newVol)
-                    config.winVol = newVol;
+                    if(config.linuxVol < newVol)
+                        vscode.window.showInformationMessage("Volume has been increased to " + newVol)
+                        else if(config.linuxVol > newVol)
+                        vscode.window.showInformationMessage("Volume has been decreased to " + newVol)
+                        else
+                        vscode.window.showWarningMessage("Volume is always at " + newVol);
+                        config.linuxVol = newVol;
                 }
 
             context.globalState.update('linux_volume', newVol);


### PR DESCRIPTION
I appreciate your work! This extension is as funny as useful. since I started the use this extension, I am more focused. However, Throughout the day I increase or decrease the sound volume naturally, it's annoying that I have to use the volume up command 5 times to go from 50 to 100. Think it's happening 5-6 times in one day. I decided to add a new command which is "Set Volume" so we can set the volume with just a command it works more efficiently now.

# Usage
Open command terminal with cmd+shift+p
type Hacker Sounds: Set Volume and press enter.
Type the volume level and press enter.